### PR TITLE
RANCHER-2321: Implement snapshot application update workflow

### DIFF
--- a/.github/workflows/app-snapshot-update.yml
+++ b/.github/workflows/app-snapshot-update.yml
@@ -1,0 +1,92 @@
+name: Update Snapshot Application
+
+run-name: Update Snapshot Application ${{ github.event_name == 'schedule' && '[scheduled]' || '' }}
+
+on:
+  schedule:
+    - cron: "*/20 * * * *"
+
+  workflow_dispatch:
+    inputs:
+      descriptor_build_offset:
+        description: 'Offset to apply to application artifact version'
+        required: false
+        type: string
+        default: '100100000000000'
+      rely_on_FAR:
+        description: 'Whether to rely on FAR for application descriptor dependencies'
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Perform dry run without making changes'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  fetch-platform-descriptor:
+    name: Fetch Platform Descriptor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Platform Repository
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.rely_on_FAR) }}
+        uses: actions/checkout@v4
+        with:
+          repository: folio-org/platform-lsp
+          ref: snapshot
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Platform Descriptor
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.rely_on_FAR) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: platform-descriptor
+          path: platform-descriptor.json
+          retention-days: 1
+
+  update-application:
+    name: Update Application
+    needs: fetch-platform-descriptor
+    uses: folio-org/kitfox-github/.github/workflows/app-update.yml@master
+    with:
+      app_name: ${{ github.event.repository.name }}
+      repo: ${{ github.repository }}
+      workflow_run_number: ${{ github.run_number }}
+      descriptor_build_offset: ${{ github.event_name == 'workflow_dispatch' && inputs.descriptor_build_offset || '100100000000000' }}
+      rely_on_FAR: ${{ github.event_name == 'workflow_dispatch' && inputs.rely_on_FAR || false }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    secrets: inherit
+
+  slack_notification:
+    name: Slack Notification
+    needs: update-application
+    if: always() && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) &&
+      (needs.update-application.result != 'success' || 
+        needs.update-application.result == 'success' && needs.update-application.outputs.updated == 'true') && 
+      vars.SLACK_NOTIF_CHANNEL != ''
+    uses: folio-org/kitfox-github/.github/workflows/app-update-notification.yml@master
+    with:
+      app_name: ${{ github.event.repository.name }}
+      repo: ${{ github.repository }}
+      new_version: ${{ needs.update-application.outputs.new_version }}
+      previous_version: ${{ needs.update-application.outputs.previous_version }}
+      updated_cnt: ${{ needs.update-application.outputs.updated_cnt }}
+      updated_modules: ${{ needs.update-application.outputs.updated_modules }}
+      updated_modules_b64: ${{ needs.update-application.outputs.updated_modules_b64 }}
+      failure_reason: ${{ needs.update-application.outputs.failure_reason }}
+      commit_sha: ${{ needs.update-application.outputs.commit_sha }}
+      app_descriptor_file_name: ${{ needs.update-application.outputs.app_descriptor_file_name }}
+      app_descriptor_url: ${{ needs.update-application.outputs.app_descriptor_url }}
+      workflow_result: ${{ needs.update-application.result }}
+      workflow_run_id: ${{ github.run_id }}
+      workflow_run_number: ${{ github.run_number }}
+      slack_notif_channel: ${{ vars.SLACK_NOTIF_CHANNEL }}
+    secrets: inherit


### PR DESCRIPTION
This PR implements the enhanced snapshot application update workflow as part of RANCHER-2321.

### What this PR adds:

**New Workflow Features:**
- Automated module version updates every 20 minutes via scheduled triggers
- Manual workflow dispatch with configurable parameters (`descriptor_build_offset`, `rely_on_FAR`, `dry_run`)
- Dual-mode operation supporting both FAR-based and traditional platform-descriptor validation
- Platform-descriptor artifact handling for non-FAR validation scenarios

**Technical Improvements:**
- Support for `descriptor_build_offset` parameter for build number management and provided prefix/increment
- Conditional platform-descriptor fetching based on `rely_on_FAR` setting
- Proper handling of both schedule and workflow_dispatch event contexts
- Integration with kitfox-github reusable workflows for consistency across applications
- Automatic detection and updates of both backend and UI module versions
- Maven artifact generation and FAR registry publication
- Git commit and push of updated application descriptors
- Slack notifications for workflow success/failure events

**Benefits:**
- Enables automated application descriptor build and update processes
- Provides flexibility for both production (FAR) and development (non-FAR) workflows  
- Maintains application currency with latest module versions
- Standardizes workflow patterns across all FOLIO applications

### Testing:
- Tested in both FAR and non-FAR modes
- Verified proper module version updates (backend and UI)
- Confirmed descriptor build number increment management with provided prefix/increment
- Validated end-to-end workflow execution

This workflow is part of the broader RANCHER-2321 initiative to improve CI/CD automation across the FOLIO ecosystem.